### PR TITLE
Bug fix in converter.py

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -3,7 +3,7 @@ from sys import argv
 
 from variables import newVariables
 
-nEvents_max = 10
+nEvents_max = -1
 nVariables = set()
 
 filename, outputFileName, inputFileNames = argv                     # "vbfHmm_powheg", "DYToLL_madgraphMLM"

--- a/script.py
+++ b/script.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-import os, sys
-
-os.system('sh DYToLL_madgraphMLM.sh')
-os.system('sh vbfHmm_powheg.sh')
-

--- a/skim.sh
+++ b/skim.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source /cvmfs/sft.cern.ch/lcg/views/LCG_99/x86_64-centos7-gcc8-opt/setup.sh
 
 PATH=$PATH:/cvmfs/cms.cern.ch/slc7_amd64_gcc700/external/llvm/8.0.1/bin/
@@ -14,9 +16,6 @@ token
 
 echo "Check xrootd", root -b -l -q  root://eoscms.cern.ch//store/group/upgrade/delphes_output/YR_Delphes/Delphes342pre14/VBFHToMuMu_M125_14TeV_powheg_pythia8_200PU/VBFHToMuMu_M125_14TeV_powheg_pythia8_1.root -e 'Delphes->Draw("","")'
 root -b -l -q  root://eoscms.cern.ch//store/group/upgrade/delphes_output/YR_Delphes/Delphes342pre14/VBFHToMuMu_M125_14TeV_powheg_pythia8_200PU/VBFHToMuMu_M125_14TeV_powheg_pythia8_1.root -e 'Delphes->Draw("","")'
-root -b -l -q root://eos/cms/store/group/upgrade/delphes_output/YR_Delphes/Delphes342pre15/GluGluHToMuMu_M125_14TeV_powheg_pythia8_200PU/GluGlu_HToMuMu_M125_14TeV_powheg_pythia8_1.root -e 'Delphes->Draw("","")'
-root -b - l -q root://eos/cms/store/group/upgrade/delphes_output/YR_Delphes/Delphes342pre15_hadd/EWKZ2Jets_ZToLL_M-50_14TeV-madgraph-pythia8_200PU/EWKZ2Jets_ZToLL_M-50_13TeV-madgraph-pythia8_1.root -e 'Delphes->Draw("","")'
 
 echo python3.8 converter.py $1 $2 
 python3.8 converter.py $1 $2
-

--- a/vbfhmumu.py
+++ b/vbfhmumu.py
@@ -1,5 +1,5 @@
 import os
-prod = "PROD_1_2"
+prod = "PROD_2_0"
 os.mkdir(prod)
 
 import htcondor  # for submitting jobs, querying HTCondor daemons, etc.


### PR DESCRIPTION
Bug fix in converter.py to make it compatible with the new python code to submit.
(You forgot to update this part of the code)

Now you can run the files in this way

```
 python converter.py EWKZ2Jets_ZToLL_madgraph_TEST.root root://eoscms.cern.ch//store/group/upgrade/delphes_output/YR_Delphes/Delphes342pre15_hadd/EWKZ2Jets_ZToLL_M-50_14TeV-madgraph-pythia8_200PU/EWKZ2Jets_ZToLL_M-50_14TeV-madgraph-pythia8_200PU_62.root,root://eoscms.cern.ch//store/group/upgrade/delphes_output/YR_Delphes/Delphes342pre15_hadd/EWKZ2Jets_ZToLL_M-50_14TeV-madgraph-pythia8_200PU/EWKZ2Jets_ZToLL_M-50_14TeV-madgraph-pythia8_200PU_63.root
```

Note that samples.py is used only in `vbfhmm.py`